### PR TITLE
Issue #26 Fix

### DIFF
--- a/open_bci_v3.py
+++ b/open_bci_v3.py
@@ -350,11 +350,6 @@ class OpenBCIBoard(object):
     self.ser.write(b'?')
     time.sleep(0.5)
     print_incoming_text();
-
-  def print_register_settings(self):
-    self.ser.write(b'?')
-    time.sleep(0.5)
-    print_incoming_text();
   #DEBBUGING: Prints individual incoming bytes
   def print_bytes_in(self):
     if not self.streaming:

--- a/open_bci_v3.py
+++ b/open_bci_v3.py
@@ -71,9 +71,6 @@ class OpenBCIBoard(object):
     self.log = log # print_incoming_text needs log
     if not port:
       port = self.find_port()
-      print(port)
-      if not port:
-        raise OSError('Cannot find OpenBCI port')
 
     print("Connecting to V3 at port %s" %(port))
     self.ser = serial.Serial(port= port, baudrate = baud, timeout=timeout)
@@ -536,6 +533,7 @@ class OpenBCIBoard(object):
       ports = glob.glob('/dev/tty.usbserial*')
     else:
       raise EnvironmentError('Error finding ports on your operating system')
+    openbci_port = ''
     for port in ports:
       try:
         s = serial.Serial(port)
@@ -543,7 +541,10 @@ class OpenBCIBoard(object):
         openbci_port = port;
       except (OSError, serial.SerialException):
         pass
-    return openbci_port
+    if openbci_port == '':
+      raise OSError('Cannot find OpenBCI port')
+    else:
+      return openbci_port
 
 class OpenBCISample(object):
   """Object encapulsating a single sample from the OpenBCI board."""

--- a/open_bci_v3.py
+++ b/open_bci_v3.py
@@ -545,10 +545,6 @@ class OpenBCIBoard(object):
         pass
     return openbci_port
 
-
-
-
-
 class OpenBCISample(object):
   """Object encapulsating a single sample from the OpenBCI board."""
   def __init__(self, packet_id, channel_data, aux_data):


### PR DESCRIPTION
I added automatic port detection for linux, mac, and windows (alternative to explicitly specifying it). The code is in the `def find_port()` on line 529. It attempts to open the usb serial ports listed in the system, and if one is available (dongle is plugged in), that port is used. Works on my linux machine! Anybody wanna test on Mac/Windows? It looks like it should work though.

Possible bug might occur when multiple serial ports are available (like if you had multiple devices plugged in to virtual com ports). In that case, the user would be forced to specify the port while instantiating the `OpenBCIBoard()` object. 
