### PR TITLE
fix for correct sample ids (0-255)!

### DIFF
--- a/open_bci_v3.py
+++ b/open_bci_v3.py
@@ -180,15 +180,15 @@ class OpenBCIBoard(object):
   """
   def _read_serial_binary(self, max_bytes_to_skip=3000):
     def read(n):
-      b = self.ser.read(n)
-      if not b:
+      bb = self.ser.read(n)
+      if not bb:
         self.warn('Device appears to be stalled. Quitting...')
         sys.exit()
         raise Exception('Device Stalled')
         sys.exit()
         return '\xFF'
       else:
-        return b
+        return bb
 
     for rep in range(max_bytes_to_skip):
 


### PR DESCRIPTION
Scope of the local variable "b"  used in def read(n) was wrong and resulted (at least) in wrong sample ids!
Renameing the variable to "bb" resolved the ambiguity and fixed the problem.