### PR TITLE
stop connection timer when no longer streaming

### DIFF
--- a/open_bci_v3.py
+++ b/open_bci_v3.py
@@ -422,6 +422,9 @@ class OpenBCIBoard(object):
 
 
   def check_connection(self, interval = 2, max_packets_to_skip=10):
+    # stop checking when we're no longer streaming
+    if not self.streaming:
+      return
     #check number of dropped packages and establish connection problem if too large
     if self.packets_dropped > max_packets_to_skip:
       #if error, attempt to reconect

--- a/open_bci_v_ganglion.py
+++ b/open_bci_v_ganglion.py
@@ -405,6 +405,9 @@ class OpenBCIBoard(object):
  
 
   def check_connection(self, interval = 2, max_packets_to_skip=10):
+    # stop checking when we're no longer streaming
+    if not self.streaming:
+      return
     #check number of dropped packages and establish connection problem if too large
     if self.packets_dropped > max_packets_to_skip:
       #if error, attempt to reconect


### PR DESCRIPTION
When I was using the standalone SDK (`open_bci_v3.py`), my program will hang after I stopped streaming. I realized that when we `start_streaming()`, it calls `check_connection()` and starts a timer thread. After we `stop()` streaming, the program will not exit because it's waiting and trying to join the timer thread.

This fix returns early from `check_connection()` if we're no longer streaming, so that we don't continuously schedule timers. I made the change in both v3 and v4 (ganglion) since its similar in both.