### PR TITLE
FIX: Streaming Ganglion over WIFI

### DIFF
--- a/openbci/wifi.py
+++ b/openbci/wifi.py
@@ -391,6 +391,21 @@ class OpenBCIWiFi(object):
         except Exception as e:
             print("Something went wrong while setting sample rate: " + str(e))
 
+    def set_accelerometer(self, toggle_position):
+        """ Enable / disable accelerometer """
+        try:
+            if self.board_type == k.BOARD_GANGLION:
+                # Commands to set toggle to on position
+                if toggle_position == 1:
+                    self.wifi_write('n')
+                # Commands to set toggle to off position
+                elif toggle_position == 0:
+                    self.wifi_write('N')
+            else:
+                print("Board type not supported for setting accelerometer")
+        except Exception as e:
+            print("Something went wrong while setting accelerometer: " + str(e))
+
     """
 
     Clean Up (atexit)

--- a/openbci/wifi.py
+++ b/openbci/wifi.py
@@ -154,6 +154,13 @@ class OpenBCIWiFi(object):
             if self.log:
                 print("Connected to %s with %s channels" % (self.board_type, self.eeg_channels_per_sample))
 
+        gains = None
+        if self.board_type == k.BOARD_CYTON:
+            gains = [24, 24, 24, 24, 24, 24, 24, 24]
+        elif self.board_type == k.BOARD_GANGLION:
+            gains = [51, 51, 51, 51]
+        self.local_wifi_server.set_parser(ParseRaw(gains=gains, board_type=self.board_type))
+
         if self.high_speed:
             output_style = 'raw'
         else:
@@ -475,3 +482,6 @@ class WiFiShieldServer(asyncore.dispatcher):
 
     def set_gains(self, gains):
         self.parser.set_ads1299_scale_factors(gains)
+
+    def set_parser(self, parser):
+        self.parser = parser

--- a/openbci/wifi.py
+++ b/openbci/wifi.py
@@ -347,6 +347,50 @@ class OpenBCIWiFi(object):
         except Exception as e:
             print("Something went wrong while setting channels: " + str(e))
 
+    def set_sample_rate(self, sample_rate):
+        """ Change sample rate """
+        try:
+            if self.board_type == k.BOARD_CYTON:
+                if sample_rate == 250:
+                        self.wifi_write('~6')
+                elif sample_rate == 500:
+                        self.wifi_write('~5')
+                elif sample_rate == 1000:
+                        self.wifi_write('~4')
+                elif sample_rate == 2000:
+                        self.wifi_write('~3')
+                elif sample_rate == 4000:
+                        self.wifi_write('~2')
+                elif sample_rate == 8000:
+                        self.wifi_write('~1')
+                elif sample_rate == 16000:
+                        self.wifi_write('~0')
+                else:
+                    print("Sample rate not supported: " + str(sample_rate))
+            elif self.board_type == k.BOARD_GANGLION:
+                if sample_rate == 200:
+                        self.wifi_write('~7')
+                elif sample_rate == 400:
+                        self.wifi_write('~6')
+                elif sample_rate == 800:
+                        self.wifi_write('~5')
+                elif sample_rate == 1600:
+                        self.wifi_write('~4')
+                elif sample_rate == 3200:
+                        self.wifi_write('~3')
+                elif sample_rate == 6400:
+                        self.wifi_write('~2')
+                elif sample_rate == 12800:
+                        self.wifi_write('~1')
+                elif sample_rate == 25600:
+                        self.wifi_write('~0')
+                else:
+                    print("Sample rate not supported: " + str(sample_rate))
+            else:
+                print("Board type not supported for setting sample rate")
+        except Exception as e:
+            print("Something went wrong while setting sample rate: " + str(e))
+
     """
 
     Clean Up (atexit)

--- a/scripts/stream_data_wifi.py
+++ b/scripts/stream_data_wifi.py
@@ -4,14 +4,14 @@ import logging
 
 
 def printData(sample):
-    print sample
+    print(sample)
 
 
 if __name__ == '__main__':
     shield_name = 'OpenBCI-E2B6'
     logging.basicConfig(filename="test.log",format='%(asctime)s - %(levelname)s : %(message)s',level=logging.DEBUG)
     logging.info('---------LOG START-------------')
-    shield = bci.OpenBCIWiFi(shield_name=shield_name, log=True)
+    shield = bci.OpenBCIWiFi(shield_name=shield_name, log=True, high_speed=False)
     print("WiFi Shield Instantiated")
     shield.start_streaming(printData)
 

--- a/scripts/stream_data_wifi_high_speed.py
+++ b/scripts/stream_data_wifi_high_speed.py
@@ -4,7 +4,8 @@ import logging
 
 
 def printData(sample):
-    print sample.sample_number
+    print(sample.sample_number)
+    print(sample.channel_data)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I had to pass gains for Ganglion into the Wifi Shield server otherwise channel data was always empty when streaming. Added for Cyton too for consistency. #51 

Also set high speed as false in the non-high speed script for streaming data over Wifi so it can output JSON data.