### PR TITLE
Add Python 3 compatibility

### DIFF
--- a/openbci/plugins/udp_server.py
+++ b/openbci/plugins/udp_server.py
@@ -7,7 +7,10 @@ Requires:
   - websockets
 """
 
-import cPickle as pickle
+try:
+    import cPickle as pickle
+except ImportError:
+    import _pickle as pickle
 import json
 import socket
 

--- a/openbci/utils/parse.py
+++ b/openbci/utils/parse.py
@@ -1,7 +1,7 @@
 import time
 import struct
 
-from constants import Constants as k
+from openbci.utils.constants import Constants as k
 
 
 class ParseRaw(object):

--- a/openbci/utils/parse.py
+++ b/openbci/utils/parse.py
@@ -174,7 +174,10 @@ class ParseRaw(object):
             sample.packet_type = packet_type
         except BaseException as e:
             sample = OpenBCISample()
-            sample.error = e.message
+            if hasattr(e, 'message'):
+                sample.error = e.message
+            else:
+                sample.error = e
             sample.valid = False
 
         return sample

--- a/openbci/utils/ssdp.py
+++ b/openbci/utils/ssdp.py
@@ -13,12 +13,18 @@
 #   limitations under the License.
 
 import socket
-import httplib
-import StringIO
+try:
+    import httplib
+except ImportError:
+    import http.client
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 
 class SSDPResponse(object):
-    class _FakeSocket(StringIO.StringIO):
+    class _FakeSocket(StringIO):
         def makefile(self, *args, **kw):
             return self
 

--- a/openbci/utils/utilities.py
+++ b/openbci/utils/utilities.py
@@ -1,4 +1,4 @@
-from constants import Constants as k
+from openbci.utils.constants import Constants as k
 
 
 def make_tail_byte_from_packet_type(packet_type):

--- a/scripts/socket_client.py
+++ b/scripts/socket_client.py
@@ -1,7 +1,7 @@
 from socketIO_client import SocketIO
 
 def on_sample(*args):
-    print args
+    print(args)
 
 socketIO = SocketIO('10.0.1.194', 8880)
 socketIO.on('openbci', on_sample)

--- a/scripts/stream_data.py
+++ b/scripts/stream_data.py
@@ -53,10 +53,10 @@ class Monitor(Thread):
             elapsed_time = new_tick - self.tick
             current_samples_in =  nb_samples_in
             current_samples_out = nb_samples_out
-            print "--- at t: ", (new_tick - self.start_tick), " ---"
-            print "elapsed_time: ", elapsed_time
-            print "nb_samples_in: ", current_samples_in - self.nb_samples_in
-            print "nb_samples_out: ", current_samples_out - self.nb_samples_out
+            print("--- at t: ", (new_tick - self.start_tick), " ---")
+            print("elapsed_time: ", elapsed_time)
+            print("nb_samples_in: ", current_samples_in - self.nb_samples_in)
+            print("nb_samples_out: ", current_samples_out - self.nb_samples_out)
             self.tick = new_tick
             self.nb_samples_in = nb_samples_in
             self.nb_samples_out = nb_samples_out
@@ -75,7 +75,7 @@ def streamData(sample):
     global last_id
     # TODO: duplicate packet if skipped to stay sync
     if sample.id != last_id + 1:
-        print "time", tick, ": paquet skipped!"
+        print("time", tick, ": paquet skipped!")
     if sample.id == 255:
         last_id = -1
     else:
@@ -109,10 +109,10 @@ def streamData(sample):
             # OK, it's a very rough interpolation
             interpol_values[i] = (last_values[i] + sample.channel_data[i]) / 2
         if DEBUG:
-            print "  --"
-            print "  last values: ", last_values
-            print "  interpolation: ", interpol_values
-            print "  current sample: ", sample.channel_data
+            print("  --")
+            print("  last values: ", last_values)
+            print("  interpolation: ", interpol_values)
+            print("  current sample: ", sample.channel_data)
         # send to clients interpolated sample
         # leftover_duplications = 0
         server.broadcast_values(interpol_values)

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -5,11 +5,11 @@ import time
 
 def printData(sample):
     #os.system('clear')
-    print "----------------"
+    print("----------------")
     print("%f" %(sample.id))
-    print sample.channel_data
-    print sample.aux_data
-    print "----------------"
+    print(sample.channel_data)
+    print(sample.aux_data)
+    print("----------------")
 
 
 

--- a/scripts/udp_client.py
+++ b/scripts/udp_client.py
@@ -1,7 +1,10 @@
 """A sample client for the OpenBCI UDP server."""
 
 import argparse
-import cPickle as pickle
+try:
+    import cPickle as pickle
+except ImportError:
+    import _pickle as pickle
 import json
 import sys; sys.path.append('..') # help python find cyton.py relative to scripts folder
 import socket
@@ -41,12 +44,12 @@ class UDPClient(object):
       if self.json:
         sample = json.loads(data)
         # In JSON mode we only recieve channel data.
-        print data
+        print(data)
       else:
         sample = pickle.loads(data)
         # Note that sample is an OpenBCISample object.
-        print sample.id
-        print sample.channel_data
+        print(sample.id)
+        print(sample.channel_data)
 
 
 args = parser.parse_args()

--- a/scripts/udp_server.py
+++ b/scripts/udp_server.py
@@ -8,7 +8,10 @@ Requires:
 """
 
 import argparse
-import cPickle as pickle
+try:
+    import cPickle as pickle
+except ImportError:
+    import _pickle as pickle
 import json
 import sys; sys.path.append('..') # help python find cyton.py relative to scripts folder
 from openbci import cyton as open_bci
@@ -49,7 +52,7 @@ class UDPServer(object):
     self.ip = ip
     self.port = port
     self.json = json
-    print "Selecting raw UDP streaming. IP: ", self.ip, ", port: ", str(self.port)
+    print("Selecting raw UDP streaming. IP: ", self.ip, ", port: ", str(self.port))
     self.server = socket.socket(
         socket.AF_INET, # Internet
         socket.SOCK_DGRAM)

--- a/test_log.py
+++ b/test_log.py
@@ -5,11 +5,11 @@ import time
 
 def printData(sample):
 	#os.system('clear')
-	print "----------------"
+	print("----------------")
 	print("%f" %(sample.id))
-	print sample.channel_data
-	print sample.aux_data
-	print "----------------"
+	print(sample.channel_data)
+	print(sample.aux_data)
+	print("----------------")
 
 
 


### PR DESCRIPTION
Now works in Python 3.x and still backwards compatible with Python 2.7.x.

I've only implemented this when using Ganglion via Wifi, so it may not work on other paths, such as via user.py, but everything should still work on Python 2.7.x. Did fix up all the print statements for Python 3 though. #56 

With user.py, tested and can confirm it works until it tries to scan Bluetooth devices but did not test further as I did not have this setup.