### PR TITLE
FIX: Wifi in Python 3

### DIFF
--- a/openbci/utils/ssdp.py
+++ b/openbci/utils/ssdp.py
@@ -13,23 +13,30 @@
 #   limitations under the License.
 
 import socket
-try:
+import sys
+pyVersion = sys.version_info[0]
+if pyVersion == 2:
+    # Imports for Python 2
     import httplib
-except ImportError:
+    from StringIO import StringIO as SocketIO
+else:
+    # Imports for Python 3+
     import http.client
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
+    from io import BytesIO as SocketIO
 
 
 class SSDPResponse(object):
-    class _FakeSocket(StringIO):
+    class _FakeSocket(SocketIO):
         def makefile(self, *args, **kw):
             return self
 
     def __init__(self, response):
-        r = httplib.HTTPResponse(self._FakeSocket(response))
+        
+        if pyVersion == 2:
+            r = httplib.HTTPResponse(self._FakeSocket(response))
+        else:
+            r = http.client.HTTPResponse(self._FakeSocket(response))
+        
         r.begin()
         self.location = r.getheader("location")
         self.usn = r.getheader("usn")
@@ -47,13 +54,17 @@ def discover(service, timeout=5, retries=1, mx=3, wifi_found_cb=None):
         'HOST: {0}:{1}',
         'MAN: "ssdp:discover"',
         'ST: {st}','MX: {mx}','',''])
+    
     socket.setdefaulttimeout(timeout)
     responses = {}
     for _ in range(retries):
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 2)
-        sock.sendto(message.format(*group, st=service, mx=mx), group)
+        sockMessage = message.format(*group, st=service, mx=mx)
+        if pyVersion == 3:
+          sockMessage = sockMessage.encode("utf-8")
+        sock.sendto(sockMessage, group)
         while True:
             try:
                 response = SSDPResponse(sock.recv(1024))
@@ -62,4 +73,4 @@ def discover(service, timeout=5, retries=1, mx=3, wifi_found_cb=None):
                 responses[response.location] = response
             except socket.timeout:
                 break
-    return responses.values()
+    return list(responses.values())

--- a/openbci/wifi.py
+++ b/openbci/wifi.py
@@ -215,7 +215,7 @@ class OpenBCIWiFi(object):
         found_shield = False
 
         def wifi_shield_found(response):
-            res = urllib2.urlopen(response.location).read()
+            res = requests.get(response.location, verify=False).text
             device_description = xmltodict.parse(res)
             cur_shield_name = str(device_description['root']['device']['serialNumber'])
             cur_base_url = str(device_description['root']['URLBase'])


### PR DESCRIPTION
Make ssdp.py work in both Python 2 and 3
Switch a urllib call in wifi.py to use requests

These changes were necessary to get wifi working with a Cyton and WiFi shield in Python 3.

ssdp.py is kind of hacky, is there a package available that would do this better?