### PR TITLE
Wifi fixes

### DIFF
--- a/openbci/utils/parse.py
+++ b/openbci/utils/parse.py
@@ -223,7 +223,7 @@ class ParseRaw(object):
             'upper': upper_sample_object.timestamp
         }
 
-        if lower_sample_object.accel_data is not None:
+        if lower_sample_object.accel_data:
             if lower_sample_object.accel_data[0] > 0 or lower_sample_object.accel_data[1] > 0 or lower_sample_object.accel_data[2] > 0:
                 daisy_sample_object.accel_data = lower_sample_object.accel_data
             else:

--- a/openbci/wifi.py
+++ b/openbci/wifi.py
@@ -129,7 +129,6 @@ class OpenBCIWiFi(object):
         s.connect(("8.8.8.8", 80))
         local_ip_address = s.getsockname()[0]
         s.close()
-        print(local_ip_address)
         return local_ip_address
 
     def getBoardType(self):

--- a/openbci/wifi.py
+++ b/openbci/wifi.py
@@ -60,7 +60,7 @@ class OpenBCIWiFi(object):
 
     def __init__(self, ip_address=None, shield_name=None, sample_rate=None, log=True, timeout=3,
                  max_packets_to_skip=20, latency=10000, high_speed=True, ssdp_attempts=5,
-                 num_channels=8):
+                 num_channels=8, local_ip_address=None):
         # these one are used
         self.daisy = False
         self.gains = None
@@ -89,7 +89,9 @@ class OpenBCIWiFi(object):
         if self.log:
             print("Welcome to OpenBCI Native WiFi Shield Driver - Please contribute code!")
 
-        self.local_ip_address = self._get_local_ip_address()
+        self.local_ip_address = local_ip_address
+        if not self.local_ip_address:
+            self.local_ip_address = self._get_local_ip_address()
 
         # Intentionally bind to port 0
         self.local_wifi_server = WiFiShieldServer(self.local_ip_address, 0)
@@ -127,6 +129,7 @@ class OpenBCIWiFi(object):
         s.connect(("8.8.8.8", 80))
         local_ip_address = s.getsockname()[0]
         s.close()
+        print(local_ip_address)
         return local_ip_address
 
     def getBoardType(self):
@@ -251,8 +254,8 @@ class OpenBCIWiFi(object):
     def wifi_write(self, output):
         """
         Pass through commands from the WiFi Shield to the Carrier board
-        :param output: 
-        :return: 
+        :param output:
+        :return:
         """
         res_command_post = requests.post("http://%s/command" % self.ip_address,
                                          json={'command': output})
@@ -417,7 +420,7 @@ class OpenBCIWiFi(object):
                 raise ValueError('Cannot set non-existant channel')
             if self.board_type == k.BOARD_GANGLION:
                 raise ValueError('Cannot use with Ganglion')
-            ch_array = list("12345678QWERTYUI")        
+            ch_array = list("12345678QWERTYUI")
             #defaults
             command = list("x1060110X")
             # Set channel
@@ -452,15 +455,15 @@ class OpenBCIWiFi(object):
                 command[6] = '1'
             command_send = ''.join(command)
             self.wifi_write(command_send)
-            
+
             #Make sure to update gain in wifi
             self.gains[channel-1] = gain
             self.local_wifi_server.set_gains(gains=self.gains)
             self.local_wifi_server.set_parser(ParseRaw(gains=self.gains, board_type=self.board_type))
-            
+
         except ValueError as e:
             print("Something went wrong while setting channel settings: " + str(e))
-    
+
     def set_sample_rate(self, sample_rate):
         """ Change sample rate """
         try:


### PR DESCRIPTION
* https://github.com/OpenBCI/OpenBCI_Python/commit/4c8c7c6ef693d2939245df17731f146e84a5d699: Sometimes, `lower_sample_object.accel_data` is an empty list and accessing its indices will therefore raise an exception. This commit fixes this.
* https://github.com/OpenBCI/OpenBCI_Python/commit/1bf1c853d8423966e76d835131cd87a9cb21708a: In some cases (for instance, when there is more than one network interface), the local IP address detection does not work as expected. This commit allows a custom binding address to be passed to the constructor.