### PR TITLE
Fix travis

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "bluepy"]
-	path = bluepy
-	url = https://github.com/IanHarvey/bluepy.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ install:
   - python setup.py build install
 
 before_install:
+  - export PYTHONPATH=$PYTHONPATH:$(pwd)
   # We need to create a (fake) display on Travis (allows Mayavi tests to run)
   - export DISPLAY=:99.0
   - /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
       - libatlas-dev
       - libatlas3gf-base
       - libblas-dev
+      - libglib2.0-dev
       - liblapack-dev
       - python-matplotlib
       - gfortran

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,14 +24,8 @@ install:
   # Install test and coverage requirements
   - pip install codecov mock nose coverage
 
-before_install:
-  - export PYTHONPATH=$PYTHONPATH:$(pwd)
-  # We need to create a (fake) display on Travis (allows Mayavi tests to run)
-  - export DISPLAY=:99.0
-  - /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset
-
-
-# command to run tests
-script: nosetests  --with-coverage --cover-package=openbci
+# Run tests
+script:
+  - nosetests  --with-coverage --cover-package=openbci
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 env:
     - PYTHON=2.7
     - PYTHON=3.4
-# command to install dependencies\
+# command to install dependencies
 cache: pip
 sudo: false
 virtualenv:
@@ -19,19 +19,14 @@ addons:
       - gfortran
       - python-tk
 install:
-  - conda create -n testenv --yes pip python=$PYTHON
-  - source activate testenv
-  - conda install --yes --quiet numpy pyserial mock nose coverage
-  - pip install codecov xmltodict bluepy
+  # Install project requirements
+  - pip install -r requirements.txt
+  # Install test and coverage requirements
+  - pip install codecov mock nose coverage
+  # Install project
   - python setup.py build install
 
-# Setup anaconda
 before_install:
-  - wget -q http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-  - chmod +x miniconda.sh
-  - ./miniconda.sh -b -p /home/travis/miniconda
-  - export PATH=/home/travis/miniconda/bin:$PATH
-  - conda update --yes --quiet conda
   # We need to create a (fake) display on Travis (allows Mayavi tests to run)
   - export DISPLAY=:99.0
   - /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1400x900x24 -ac +extension GLX +render -noreset

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,6 @@ install:
   - pip install -r requirements.txt
   # Install test and coverage requirements
   - pip install codecov mock nose coverage
-  # Install project
-  - python setup.py build install
 
 before_install:
   - export PYTHONPATH=$PYTHONPATH:$(pwd)

--- a/README.md
+++ b/README.md
@@ -120,9 +120,9 @@ For additional details on connecting your Cyton board visit: http://docs.openbci
 
 ### Ganglion Board
 
-The Ganglion board relies on Bluetooth Low Energy connectivity (BLE). You should also retrieve the bluepy submodule for a more up-to-date version than the version `1.0.5` available at that time through `pip`. To do so, clone this repo with the `--recursive` flag then type `make` inside `bluepy/bluepy`. Note that you may need to run the script with root privileges to for some functionality, e.g. auto-detect MAC address.
+The Ganglion board relies on Bluetooth Low Energy connectivity (BLE).
 
-You may also need to alter the settings of your bluetooth adapter in order to reduce latency and avoid packet drops -- e.g. if the terminal spams "Warning: Dropped 1 packets" several times a seconds, DO THAT.
+You may need to alter the settings of your bluetooth adapter in order to reduce latency and avoid packet drops -- e.g. if the terminal spams "Warning: Dropped 1 packets" several times a seconds, DO THAT.
 
 On linux, assuming `hci0` is the name of your bluetooth adapter:
 


### PR DESCRIPTION
This removes the BluePy submodule in order to get Travis CI working. It also greatly simplifies the Travis file.  Fixes #95 .

It looks like BluePy was originally a submodule because GitHub had a more up to date version, which was required by the Ganglion board. PyPi now has version 1.2.0, and thus this should not be an issue. 

Separately, `requirements.txt` should probably be updated from having `bluepy==1.0.5` to `bluepy>=1.0.5` or something similar. I do not have a Ganglion board to test which minimum version is actually required. 