### PR TITLE
Clean up BluePy import

### DIFF
--- a/openbci/ganglion.py
+++ b/openbci/ganglion.py
@@ -23,19 +23,7 @@ import numpy as np
 import sys
 import pdb
 import glob
-# local bluepy should take precedence
-import sys
-sys.path.insert(0,"bluepy/bluepy")
-
-STUB_BTLE = False
-
-try:
-    from btle import Scanner, DefaultDelegate, Peripheral
-except:
-    DefaultDelegate = object
-    STUB_BTLE = True
-else:
-    from bluepy.btle import Scanner, DefaultDelegate, Peripheral    
+from bluepy.btle import Scanner, DefaultDelegate, Peripheral
 
 
 SAMPLE_RATE = 200.0  # Hz


### PR DESCRIPTION
This should resolve #87 and #103 by cleaning up the BluePy import. 

Previously trying to instantiate the driver with port as "TEST" would result in this error:
```
Traceback (most recent call last):
  File "/home/ian/PycharmProjects/OpenBCI_Python/openbci/test.py", line 3, in <module>
    driver = OpenBCIGanglion(port="AUTO")
  File "/home/ian/PycharmProjects/OpenBCI_Python/openbci/ganglion.py", line 94, in __init__
    self.connect()
  File "/home/ian/PycharmProjects/OpenBCI_Python/openbci/ganglion.py", line 121, in connect
    self.gang = Peripheral(self.port, 'random') # ADDR_TYPE_RANDOM
NameError: global name 'Peripheral' is not defined
```

While after this patch it errors on "TEST" not being a MAC address as expected. 
```
Traceback (most recent call last):
Looking for Ganglion board
  File "/home/ian/PycharmProjects/OpenBCI_Python/openbci/test.py", line 3, in <module>
Init BLE connection with MAC: TEST
    driver = OpenBCIGanglion(port="TEST")
NB: if it fails, try with root privileges.
  File "/home/ian/PycharmProjects/OpenBCI_Python/openbci/ganglion.py", line 82, in __init__
    self.connect()
  File "/home/ian/PycharmProjects/OpenBCI_Python/openbci/ganglion.py", line 109, in connect
    self.gang = Peripheral(self.port, 'random') # ADDR_TYPE_RANDOM
  File "/home/ian/PycharmProjects/OpenBCI_Python/venv/local/lib/python2.7/site-packages/bluepy/btle.py", line 318, in __init__
    self.connect(deviceAddr, addrType, iface)
  File "/home/ian/PycharmProjects/OpenBCI_Python/venv/local/lib/python2.7/site-packages/bluepy/btle.py", line 350, in connect
    raise ValueError("Expected MAC address, got %s" % repr(addr))
ValueError: Expected MAC address, got 'TEST'
```

Ganglion has a bunch of other small bugs in it, but I was kinda hoping that my style pull request would be merged in before working on them. 