### PR TITLE
Fix cross platform issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ addons:
 install:
   # Install project requirements
   - pip install -r requirements.txt
+  # Install BluePy for Ganglion because Travis runs Linux
+  - pip install bluepy
   # Install test and coverage requirements
   - pip install codecov mock nose coverage
 

--- a/README.md
+++ b/README.md
@@ -114,17 +114,21 @@ NOTE: For comprehensive list see requirments.txt: (https://github.com/OpenBCI/Op
 
 OpenBCI 8 and 32 bit board with 8 or 16 channels.
 
-This library includes the main open_bci_v3 class definition that instantiates an OpenBCI Board object. This object will initialize communication with the board and get the environment ready for data streaming. This library is designed to work with iOS and Linux distributions. To use a Windows OS, change the __init__ function in open_bci_v3.py to establish a serial connection in Windows.
+This library includes the OpenBCICyton and OpenBCIGanglion classes which are drivers for their respective devices. The OpenBCICyton class is designed to work on all systems, while the OpenBCIGanglion class relies on a Bluetooth driver that is only available on Linux, discussed in the next section.
 
 For additional details on connecting your Cyton board visit: http://docs.openbci.com/Hardware/02-Cyton
 
 ### Ganglion Board
 
-The Ganglion board relies on Bluetooth Low Energy connectivity (BLE).
+The Ganglion board relies on Bluetooth Low Energy connectivity (BLE), and our code relies on the BluePy library to communicate with it. The BluePy library currently only works on Linux-based operating systems. To use Ganglion you will need to install it:
 
-You may need to alter the settings of your bluetooth adapter in order to reduce latency and avoid packet drops -- e.g. if the terminal spams "Warning: Dropped 1 packets" several times a seconds, DO THAT.
+`pip install bluepy`
 
-On linux, assuming `hci0` is the name of your bluetooth adapter:
+You may be able to use the Ganglion board from a virtual machine (VM) running Linux on other operating systems, such as MacOS or Windows. See [this thread](https://github.com/OpenBCI/OpenBCI_Python/issues/68) for advice.
+
+You may need to alter the settings of your Bluetooth adapter in order to reduce latency and avoid packet drops -- e.g. if the terminal spams "Warning: Dropped 1 packets" several times a seconds, DO THAT.
+
+On Linux, assuming `hci0` is the name of your bluetooth adapter:
 
 `sudo bash -c 'echo 9 > /sys/kernel/debug/bluetooth/hci0/conn_min_interval'`
 

--- a/README.md
+++ b/README.md
@@ -257,7 +257,6 @@ Warning: Connecting pins to high frequency 2x amp signal
 --> a
 Corresponding SD file OBCI_18.TXT$$$
 --> /start T:3
-
 ```
 
 NOTES:
@@ -300,37 +299,37 @@ Note: type `/start` to launch the selected plugins.
 Add new functionalities to user.py by creating new scripts inside the `plugins` folder. You class must inherit from yapsy.IPlugin, see below a minimal example with `print` plugin:
 
 ```python
-	import plugin_interface as plugintypes
+import plugin_interface as plugintypes
 
-	class PluginPrint(plugintypes.IPluginExtended):
-		def activate(self):
-			print "Print activated"
+class PluginPrint(plugintypes.IPluginExtended):
+    def activate(self):
+        print("Print activated")
 
-		def deactivate(self):
-			print "Goodbye"
+    def deactivate(self):
+        print("Goodbye")
 
-		def show_help(self):
-			print "I do not need any parameter, just printing stuff."
+    def show_help(self):
+        print("I do not need any parameter, just printing stuff.")
 
-		# called with each new sample
-		def __call__(self, sample):
-			print "----------------"
-			print("%f" %(sample.id))
-			print sample.channel_data
-			print sample.aux_data
+    # called with each new sample
+    def __call__(self, sample):
+        print("----------------")
+        print("%f" % sample.id)
+        print(sample.channel_data)
+        print(sample.aux_data)
 ```
 
 Describe your plugin with a corresponding `print.yapsy-plugin`:
 
 ```
-	[Core]
-	Name = print
-	Module = print
+[Core]
+Name = print
+Module = print
 
-	[Documentation]
-	Author = Various
-	Version = 0.1
-	Description = Print board values on stdout
+[Documentation]
+Author = Various
+Version = 0.1
+Description = Print board values on stdout
 ```
 
 

--- a/openbci/__init__.py
+++ b/openbci/__init__.py
@@ -1,9 +1,6 @@
-
 from .cyton import OpenBCICyton
-from .ganglion import OpenBCIGanglion
 from .plugins import *
 from .utils import *
 from .wifi import OpenBCIWiFi
-
-
-__version__ = "1.0.0"
+if sys.platform.startswith("linux"):
+    from .ganglion import OpenBCIGanglion

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,4 @@ socketIO-client==0.6.5
 websocket-client==0.32.0
 wheel==0.24.0
 Yapsy==1.11.23
-bluepy==1.0.5
 xmltodict


### PR DESCRIPTION
This implements the changes discussed in #112. Specifically removing bluepy from `requirements.txt`, adding a section in the `README` about the need to install it to use the Ganglion code, and adding a if `sys.platform == "linux"` check to import ganglion in `__init__.py` to allow all code except Ganglion to be used on all platforms.

Resolves #39, resolves #68, resolves #72, resolves #86, resolves #98, resolves #112.
