### PR TITLE
ADD: Aux data to fix wifi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.1.0
+
+### New Features
+
+* Now supporting digital and analog reading on cyton wifi
+
 # v1.0.2
 
 ### Bug Fixes

--- a/openbci/utils/constants.py
+++ b/openbci/utils/constants.py
@@ -92,3 +92,8 @@ class Constants:
     SAMPLE_RATE_6400 = 6400
     SAMPLE_RATE_800 = 800
     SAMPLE_RATE_8000 = 8000
+
+    """Different Aux Modes"""
+    AUX_MODE_ANALOG = 'analog'
+    AUX_MODE_DEFAULT = 'default'
+    AUX_MODE_DIGITAL = 'digital'

--- a/openbci/utils/parse.py
+++ b/openbci/utils/parse.py
@@ -156,7 +156,51 @@ class ParseRaw(object):
         return sample_object
 
     def parse_packet_standard_raw_aux(self, raw_data_to_sample):
-        pass
+        """
+
+        :param raw_data_to_sample: RawDataToSample
+        :return:
+        """
+        # Check to make sure data is not null.
+        if raw_data_to_sample is None:
+            raise RuntimeError(k.ERROR_UNDEFINED_OR_NULL_INPUT)
+        if raw_data_to_sample.raw_data_packet is None:
+            raise RuntimeError(k.ERROR_UNDEFINED_OR_NULL_INPUT)
+
+        # Check to make sure the buffer is the right size.
+        if len(raw_data_to_sample.raw_data_packet) != k.RAW_PACKET_SIZE:
+            raise RuntimeError(k.ERROR_INVALID_BYTE_LENGTH)
+
+        # Verify the correct stop byte.
+        if raw_data_to_sample.raw_data_packet[0] != k.RAW_BYTE_START:
+            raise RuntimeError(k.ERROR_INVALID_BYTE_START)
+
+        sample_object = OpenBCISample()
+
+        sample_object.aux_data = raw_data_to_sample.raw_data_packet[k.RAW_PACKET_POSITION_START_AUX:k.RAW_PACKET_POSITION_STOP_AUX+1]
+
+        sample_object.packet_type = k.RAW_PACKET_TYPE_STANDARD_RAW_AUX
+
+        sample_object.channel_data = self.get_channel_data_array(raw_data_to_sample)
+
+        sample_object.sample_number = raw_data_to_sample.raw_data_packet[
+            k.RAW_PACKET_POSITION_SAMPLE_NUMBER
+        ]
+        sample_object.start_byte = raw_data_to_sample.raw_data_packet[
+            k.RAW_PACKET_POSITION_START_BYTE
+        ]
+        sample_object.stop_byte = raw_data_to_sample.raw_data_packet[
+            k.RAW_PACKET_POSITION_STOP_BYTE
+        ]
+
+        sample_object.valid = True
+
+        now_ms = int(round(time.time() * 1000))
+
+        sample_object.timestamp = now_ms
+        sample_object.boardTime = 0
+
+        return sample_object
 
     def parse_packet_time_synced_accel(self, raw_data_to_sample):
         pass
@@ -370,3 +414,5 @@ class OpenBCISample(object):
         self._timestamps = {}
         self.valid = valid
         self.accel_data = accel_data if accel_data is not None else []
+        self.analog_data = {}
+        self.digital_data = {}

--- a/tests/test_wifi.py
+++ b/tests/test_wifi.py
@@ -1,6 +1,9 @@
 from unittest import TestCase, main, skip
 import mock
 
+import sys, os
+sys.path.insert(1, os.path.join(sys.path[0], '..'))
+
 from openbci import OpenBCIWiFi
 
 
@@ -17,6 +20,7 @@ class TestOpenBCIWiFi(TestCase):
         expected_latency = 5000
         expected_high_speed = False
         expected_ssdp_attempts = 2
+        expected_aux_mode = 'analog'
 
         wifi = OpenBCIWiFi(ip_address=expected_ip_address,
                            shield_name=expected_shield_name,
@@ -26,7 +30,8 @@ class TestOpenBCIWiFi(TestCase):
                            max_packets_to_skip=expected_max_packets_to_skip,
                            latency=expected_latency,
                            high_speed=expected_high_speed,
-                           ssdp_attempts=expected_ssdp_attempts)
+                           ssdp_attempts=expected_ssdp_attempts,
+                           aux_mode=expected_aux_mode)
 
         self.assertEqual(wifi.ip_address, expected_ip_address)
         self.assertEqual(wifi.shield_name, expected_shield_name)
@@ -37,6 +42,7 @@ class TestOpenBCIWiFi(TestCase):
         self.assertEqual(wifi.latency, expected_latency)
         self.assertEqual(wifi.high_speed, expected_high_speed)
         self.assertEqual(wifi.ssdp_attempts, expected_ssdp_attempts)
+        self.assertEqual(wifi.aux_mode, expected_aux_mode)
 
         mock_on_shield_found.assert_called_with(expected_ip_address)
 


### PR DESCRIPTION
# v1.1.0

### New Features

* Now supporting digital and analog reading on cyton wifi

fixes #109 
Example:
```
from openbci import wifi as bci
# for analog
shield = bci.OpenBCIWiFi(ip_address = '192.168.1.141', log=True, high_speed=True, aux_mode='analog')

# for digital
shield = bci.OpenBCIWiFi(ip_address = '192.168.1.141', log=True, high_speed=True, aux_mode='digital')

def printData(sample):
    print(sample.sample_number)
    print(sample.channel_data)
    print(sample.analog_data)
    print(sample.digital_data)

shield.start_streaming(printData)
shield.loop()
```