### PR TITLE
Remove libatlas3gf-base from Travis apt get

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ addons:
   apt:
     packages:
       - libatlas-dev
-      - libatlas3gf-base
       - libblas-dev
       - libglib2.0-dev
       - liblapack-dev


### PR DESCRIPTION
This will be a work in progress until I finish stripping out everything Travis doesn't need, to prevent this error from effecting us in the future. Don't merge until it's done. 